### PR TITLE
Fix breaking changes from openzeppelin ERC721 interface

### DIFF
--- a/contracts/MyNFT.sol
+++ b/contracts/MyNFT.sol
@@ -7,14 +7,13 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 
-contract MyNFT is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
+contract  MyNFT is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
     using Counters for Counters.Counter;
 
     Counters.Counter private _tokenIdCounter;
 
     constructor() ERC721("MyNFT", "MNFT") {}
 
-//    mint an NFT
     function safeMint(address to, string memory uri) public onlyOwner {
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
@@ -24,19 +23,17 @@ contract MyNFT is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
 
     // The following functions are overrides required by Solidity.
 
-    function _beforeTokenTransfer(address from, address to, uint256 tokenId)
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId, uint256 batchSize)
         internal
         override(ERC721, ERC721Enumerable)
     {
-        super._beforeTokenTransfer(from, to, tokenId);
+        super._beforeTokenTransfer(from, to, tokenId, batchSize);
     }
 
-    //    destroy an NFT
     function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
         super._burn(tokenId);
     }
 
-    //    return IPFS url of NFT metadata
     function tokenURI(uint256 tokenId)
         public
         view

--- a/contracts/MyNFT.sol
+++ b/contracts/MyNFT.sol
@@ -13,7 +13,7 @@ contract  MyNFT is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
     Counters.Counter private _tokenIdCounter;
 
     constructor() ERC721("MyNFT", "MNFT") {}
-
+    //    mint an NFT
     function safeMint(address to, string memory uri) public onlyOwner {
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
@@ -29,11 +29,11 @@ contract  MyNFT is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
     {
         super._beforeTokenTransfer(from, to, tokenId, batchSize);
     }
-
+     //    destroy an NFT
     function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
         super._burn(tokenId);
     }
-
+    //    return IPFS url of NFT metadata
     function tokenURI(uint256 tokenId)
         public
         view


### PR DESCRIPTION
[Breaking changes](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md
)

- Added additional argument required by the hooks _beforeTokenTransfer and _afterTokenTransfer for overriding.